### PR TITLE
Change the db connection to a better instance name

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -5,13 +5,13 @@ var rootPath = path.normalize(__dirname + '/../..');
 module.exports = {
     development: {
         rootPath: rootPath,
-        db: 'mongodb://localhost/basicMean',
+        db: 'mongodb://localhost/meanBrew',
         port: process.env.PORT || 3030
 
     },
     production: {
         rootPath: rootPath,
-        db: 'mongodb://justinrassier:V4LknrMGaipw7Ba@ds033059.mongolab.com:33059/basicmean',
+        db: '', //TODO: Setup when we get a real Heroku/MongoLab instance that we want to connect to
         port: process.env.PORT || 80
     }
 


### PR DESCRIPTION
Change the db connection string to be meanBrew instead of the old template for basicMean.
